### PR TITLE
Task 21-ADVANCED-GET/api/articles/article_id/comments-pagination

### DIFF
--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -8,10 +8,11 @@ const {
 
 exports.getCommentsByArticleId = (req, res, next) => {
   const { article_id } = req.params;
+  const { limit, page } = req.query;
 
-  fetchCommentsByArticleId(article_id)
-    .then((comments) => {
-      res.status(200).send({ comments });
+  fetchCommentsByArticleId(article_id, limit, page)
+    .then(({ comments, total_count }) => {
+      res.status(200).send({ comments, total_count });
     })
     .catch(next);
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -195,34 +195,43 @@
   "GET /api/articles/:article_id/comments": {
     "description": "serves an array of comments for a given article_id",
     "details": {
-      "queries": [],
-      "exampleResponse": {
-        "comments": [
-          {
-            "comment_id": 1,
-            "votes": 16,
-            "created_at": "2020-03-28T00:10:20.000Z",
-            "author": "butter_bridge",
-            "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
-            "article_id": 9
-          },
-          {
-            "comment_id": 2,
-            "votes": 14,
-            "created_at": "2020-11-01T12:56:20.000Z",
-            "author": "butter_bridge",
-            "body": "The beautiful thing about treasure is that it exists. Got to find out what kind of sheets these are; not cotton, not rayon, silky.",
-            "article_id": 1
-          },
-          {
-            "comment_id": 3,
-            "votes": 100,
-            "created_at": "2020-03-05T16:46:20.000Z",
-            "author": "icellusedkars",
-            "body": "Replacing the quiet elegance of the dark suit and tie with the casual indifference of these muted earth tones is a form of fashion suicide, but, uh, call me crazy — onyou it works.",
-            "article_id": 1
+      "queries": {
+        "limit": "Limits the number of responses (defaults to 10)",
+        "page": "Specifies the page at which to start (calculated using limit)"
+      },
+      "successResponses": {
+        "200": {
+          "description": "Success",
+          "exampleResponse": {
+            "comments": [
+              {
+                "comment_id": 1,
+                "votes": 16,
+                "created_at": "2020-03-28T00:10:20.000Z",
+                "author": "butter_bridge",
+                "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
+                "article_id": 9
+              },
+              {
+                "comment_id": 2,
+                "votes": 14,
+                "created_at": "2020-11-01T12:56:20.000Z",
+                "author": "butter_bridge",
+                "body": "The beautiful thing about treasure is that it exists. Got to find out what kind of sheets these are; not cotton, not rayon, silky.",
+                "article_id": 1
+              },
+              {
+                "comment_id": 3,
+                "votes": 100,
+                "created_at": "2020-03-05T16:46:20.000Z",
+                "author": "icellusedkars",
+                "body": "Replacing the quiet elegance of the dark suit and tie with the casual indifference of these muted earth tones is a form of fashion suicide, but, uh, call me crazy — onyou it works.",
+                "article_id": 1
+              }
+            ],
+            "total_count": 15
           }
-        ]
+        }
       },
       "errorResponses": {
         "404": {
@@ -288,13 +297,15 @@
     "details": {
       "queries": [],
       "exampleResponse": {
-        "comment": {
-          "comment_id": 1,
-          "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
-          "article_id": 9,
-          "author": "butter_bridge",
-          "votes": 16,
-          "created_at": "2020-04-06T12:17:00.000Z"
+        "200": {
+          "comments": {
+            "comment_id": 1,
+            "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
+            "article_id": 9,
+            "author": "butter_bridge",
+            "votes": 16,
+            "created_at": "2020-04-06T12:17:00.000Z"
+          }
         }
       },
       "errorResponses": {


### PR DESCRIPTION
- add pagination when retrieving comments for an article

Accepts the following queries:

- limit, which limits the number of responses (defaults to 10).
- page and specifies the page at which to start (calculated using limit).

Responds with:

- the comments paginated according to the above inputs.